### PR TITLE
Fix an array handling error in get_multi()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.1
+
+* Fix an error in `get_multi()`. If no values are found for given keys, the method sets empty values to prevent errors in array handling.
+
 ## 1.5.0
 
 * All ignored cache group comparisons use strict string comparison.

--- a/object-cache.php
+++ b/object-cache.php
@@ -714,6 +714,12 @@ class WP_Object_Cache {
                 // Retrieve from cache in a single request
                 $group_cache = $this->redis->mget( $derived_keys );
 
+                // If there are no values in cache,
+                // populate as many empty values (false) as there are keys given.
+                if ( empty( $group_cache ) ) {
+                    $group_cache = array_fill( 0, count( $derived_keys ) - 1, false );
+                }
+
                 // Build an array of values looked up, keyed by the derived cache key
                 $group_cache = array_combine( $derived_keys, $group_cache );
 


### PR DESCRIPTION
* Fix an error in `get_multi()`. If no values are found for given keys, the method sets empty values to prevent errors in array handling.